### PR TITLE
Adjustments for better maintainability

### DIFF
--- a/serialize.go
+++ b/serialize.go
@@ -32,7 +32,7 @@ type Field struct {
 }
 
 // Serialize is a func to serialize/parse all content about the struct input
-func Serialize(validationSubject interface{}, tn ...string) ([]Field, error) {
+func serialize(validationSubject interface{}, tn ...string) ([]Field, error) {
 	if tn == nil {
 		tn = []string{DefaultTagName}
 	}
@@ -93,7 +93,7 @@ func Serialize(validationSubject interface{}, tn ...string) ([]Field, error) {
 		if kindOfField := field.Type.Kind(); kindOfField == reflect.Struct {
 			if fieldConverted := fieldValue.Convert(fieldValue.Type()); fieldConverted.CanInterface() {
 				payload := fieldConverted.Interface()
-				serialized, err := Serialize(payload, tn...)
+				serialized, err := serialize(payload, tn...)
 				if err != nil {
 					return nil, err
 				}
@@ -111,7 +111,7 @@ func Serialize(validationSubject interface{}, tn ...string) ([]Field, error) {
 				sliceFieldValue := fieldValue.Index(i)
 				if sliceFieldConverted := sliceFieldValue.Convert(sliceFieldValue.Type()); sliceFieldConverted.CanInterface() {
 					payload := sliceFieldValue.Convert(sliceFieldValue.Type()).Interface()
-					serialized, err := Serialize(payload, tn...)
+					serialized, err := serialize(payload, tn...)
 					if err != nil {
 						return nil, err
 					}

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -36,7 +36,7 @@ func TestSerializeBodyStruct(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		_, err := Serialize(c.param)
+		_, err := serialize(c.param)
 		if _, ok := err.(*ErrInvalidBody); ok == c.ok {
 			t.Error(err)
 		}
@@ -69,7 +69,7 @@ func TestSerializeBodyTagFormat(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		_, err := Serialize(c.param)
+		_, err := serialize(c.param)
 		if _, ok := err.(*ErrInvalidTag); ok == c.ok {
 			t.Error(err)
 		}
@@ -83,7 +83,7 @@ func TestSerialize(t *testing.T) {
 		C bool   `validate:"test test_number=true"`
 	}{"a-value", 10, true}
 
-	fields, err := Serialize(body)
+	fields, err := serialize(body)
 	if err != nil {
 		t.Error(err)
 		return
@@ -114,7 +114,7 @@ func TestSliceSerialize(t *testing.T) {
 		B []TestSerializeSliceA
 	}{"a-value", []TestSerializeSliceA{{10}, {}}}
 
-	fields, err := Serialize(body)
+	fields, err := serialize(body)
 	if err != nil {
 		t.Error(err)
 		return
@@ -151,7 +151,7 @@ func TestStructSlice(t *testing.T) {
 		B TestSerializeStructD
 	}{"a-value", TestSerializeStructD{J: "j-test-struct", I: TestSerializeStructE{a: "a-test-private-struct-field"}}}
 
-	fields, err := Serialize(body)
+	fields, err := serialize(body)
 	if err != nil {
 		t.Error(err)
 		return
@@ -172,6 +172,6 @@ func BenchmarkSerializeBodyStruct(b *testing.B) {
 	b.ResetTimer()
 	body := map[string]string{"test-key": "test-value"}
 	for n := 0; n < b.N; n++ {
-		Serialize(body)
+		serialize(body)
 	}
 }

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -168,19 +168,6 @@ func TestStructSlice(t *testing.T) {
 	}
 }
 
-func TestRawSerializeWithEmptyTagName(t *testing.T) {
-	_, err := RawSerialize("", nil)
-	if err == nil {
-		t.Error("Unexpected nil value for error")
-		return
-	}
-
-	if _, ok := err.(*ErrEmptyTagName); !ok {
-		t.Error("Unexpected error type, not equal *ErrEmptyTagName")
-		return
-	}
-}
-
 func BenchmarkSerializeBodyStruct(b *testing.B) {
 	b.ResetTimer()
 	body := map[string]string{"test-key": "test-value"}

--- a/validate.go
+++ b/validate.go
@@ -2,16 +2,17 @@ package gody
 
 import "github.com/guiferpa/gody/rule"
 
-func DefaultValidate(b interface{}, customRules []Rule) (bool, error) {
-	return RawDefaultValidate(b, DefaultTagName, customRules)
+// DefaultValidate validates the validation subject against pre-defined rules
+func DefaultValidate(validationSubject interface{}, customRules []Rule) (bool, error) {
+	return RawDefaultValidate(validationSubject, DefaultTagName, customRules)
 }
 
 // Validate contains the entrypoint to validation of struct input
-func Validate(b interface{}, rules []Rule) (bool, error) {
-	return RawValidate(b, DefaultTagName, rules)
+func Validate(validationSubject interface{}, rules []Rule) (bool, error) {
+	return RawValidate(validationSubject, DefaultTagName, rules)
 }
 
-func RawDefaultValidate(b interface{}, tn string, customRules []Rule) (bool, error) {
+func RawDefaultValidate(validationSubject interface{}, tn string, customRules []Rule) (bool, error) {
 	defaultRules := []Rule{
 		rule.NotEmpty,
 		rule.Required,
@@ -22,11 +23,11 @@ func RawDefaultValidate(b interface{}, tn string, customRules []Rule) (bool, err
 		rule.MinBound,
 	}
 
-	return RawValidate(b, tn, append(defaultRules, customRules...))
+	return RawValidate(validationSubject, tn, append(defaultRules, customRules...))
 }
 
-func RawValidate(b interface{}, tn string, rules []Rule) (bool, error) {
-	fields, err := RawSerialize(tn, b)
+func RawValidate(validationSubject interface{}, tn string, rules []Rule) (bool, error) {
+	fields, err := RawSerialize(tn, validationSubject)
 	if err != nil {
 		return false, err
 	}

--- a/validate.go
+++ b/validate.go
@@ -3,16 +3,7 @@ package gody
 import "github.com/guiferpa/gody/rule"
 
 // DefaultValidate validates the validation subject against pre-defined rules
-func DefaultValidate(validationSubject interface{}, customRules []Rule) (bool, error) {
-	return RawDefaultValidate(validationSubject, DefaultTagName, customRules)
-}
-
-// Validate contains the entrypoint to validation of struct input
-func Validate(validationSubject interface{}, rules []Rule) (bool, error) {
-	return RawValidate(validationSubject, DefaultTagName, rules)
-}
-
-func RawDefaultValidate(validationSubject interface{}, tn string, customRules []Rule) (bool, error) {
+func DefaultValidate(validationSubject interface{}, customRules []Rule, tn ...string) (bool, error) {
 	defaultRules := []Rule{
 		rule.NotEmpty,
 		rule.Required,
@@ -23,19 +14,20 @@ func RawDefaultValidate(validationSubject interface{}, tn string, customRules []
 		rule.MinBound,
 	}
 
-	return RawValidate(validationSubject, tn, append(defaultRules, customRules...))
+	return Validate(validationSubject, append(defaultRules, customRules...), tn...)
 }
 
-func RawValidate(validationSubject interface{}, tn string, rules []Rule) (bool, error) {
-	fields, err := RawSerialize(tn, validationSubject)
+// Validate contains the entrypoint to validation of struct input
+func Validate(validationSubject interface{}, rules []Rule, tn ...string) (bool, error) {
+	fields, err := Serialize(validationSubject, tn...)
 	if err != nil {
 		return false, err
 	}
 
-	return ValidateFields(fields, rules)
+	return validateFields(fields, rules)
 }
 
-func ValidateFields(fields []Field, rules []Rule) (bool, error) {
+func validateFields(fields []Field, rules []Rule) (bool, error) {
 	for _, field := range fields {
 		for _, r := range rules {
 			val, ok := field.Tags[r.Name()]

--- a/validate.go
+++ b/validate.go
@@ -19,7 +19,7 @@ func DefaultValidate(validationSubject interface{}, customRules []Rule, tn ...st
 
 // Validate contains the entrypoint to validation of struct input
 func Validate(validationSubject interface{}, rules []Rule, tn ...string) (bool, error) {
-	fields, err := Serialize(validationSubject, tn...)
+	fields, err := serialize(validationSubject, tn...)
 	if err != nil {
 		return false, err
 	}

--- a/validator.go
+++ b/validator.go
@@ -32,7 +32,7 @@ func (v *Validator) SetTagName(tn string) {
 }
 
 func (v *Validator) Validate(b interface{}) (bool, error) {
-	return RawDefaultValidate(b, v.tagName, v.addedRules)
+	return DefaultValidate(b, v.addedRules, v.tagName)
 }
 
 func NewValidator() *Validator {


### PR DESCRIPTION
Unexported functions which were not needed by outside user, added some documentation, made tag name optional and made "validate" the default tag name when none is passed. Validate now accepts many tag names, and uses any of the tag names to serialize when found.