### PR TITLE
Set rule from dynamic values

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ gody.RawDefaultValidate(interface{}, string, []gody.Rule) (bool, error)
 gody.DefaultValidate(interface{}, []gody.Rule) (bool, error)
 ```
 
+### Dynamic Enum Validation (No Duplication)
+
+You can avoid duplicating enum values in struct tags by using dynamic parameters:
+
+```go
+const (
+    StatusCreated = "__CREATED__"
+    StatusPending = "__PENDING__"
+    StatusDoing   = "__DOING__"
+    StatusDone    = "__DONE__"
+)
+
+type Task struct {
+    Name   string `json:"name"`
+    Status string `json:"status" validate:"enum={status}"`
+}
+
+validator := gody.NewValidator()
+validator.AddRuleParameters(map[string]string{
+    "status": fmt.Sprintf("%s,%s,%s,%s", StatusCreated, StatusPending, StatusDoing, StatusDone),
+})
+validator.AddRules(rule.Enum)
+
+// Now you can validate Task structs without duplicating enum values in the tag!
+```
+
 ### Contribution policies
 
 1. At this time the only policy is don't create a Pull Request directly, it's necessary some discussions for some implementation then open an issue before to dicussion anything about the project.

--- a/rule/enum.go
+++ b/rule/enum.go
@@ -32,5 +32,5 @@ func (r *enum) Validate(f, v, p string) (bool, error) {
 			return true, nil
 		}
 	}
-	return true, &ErrEnum{f, v, es}
+	return false, &ErrEnum{f, v, es}
 }

--- a/rule/enum.go
+++ b/rule/enum.go
@@ -32,5 +32,5 @@ func (r *enum) Validate(f, v, p string) (bool, error) {
 			return true, nil
 		}
 	}
-	return false, &ErrEnum{f, v, es}
+	return true, &ErrEnum{f, v, es}
 }

--- a/rule/enum_test.go
+++ b/rule/enum_test.go
@@ -43,7 +43,7 @@ func TestEnumWithInvalidParams(t *testing.T) {
 	}
 	for _, test := range cases {
 		ok, err := r.Validate("", test.value, test.param)
-		if _, okErr := err.(*ErrEnum); !okErr {
+		if _, isErrEnum := err.(*ErrEnum); !isErrEnum {
 			t.Error(err)
 		}
 		if ok {

--- a/rule/enum_test.go
+++ b/rule/enum_test.go
@@ -43,11 +43,11 @@ func TestEnumWithInvalidParams(t *testing.T) {
 	}
 	for _, test := range cases {
 		ok, err := r.Validate("", test.value, test.param)
-		if _, ok := err.(*ErrEnum); !ok {
+		if _, okErr := err.(*ErrEnum); !okErr {
 			t.Error(err)
 		}
-		if !ok {
-			t.Errorf("unexpected result, result: %v, expected: %v", ok, true)
+		if ok {
+			t.Errorf("unexpected result, result: %v, expected: %v", ok, false)
 		}
 	}
 }

--- a/validate.go
+++ b/validate.go
@@ -1,6 +1,10 @@
 package gody
 
-import "github.com/guiferpa/gody/v2/rule"
+import (
+	"strings"
+
+	"github.com/guiferpa/gody/v2/rule"
+)
 
 func DefaultValidate(b any, customRules []Rule) (bool, error) {
 	return RawDefaultValidate(b, DefaultTagName, customRules)
@@ -49,4 +53,51 @@ func ValidateFields(fields []Field, rules []Rule) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func RawDefaultValidateWithParams(b any, tn string, customRules []Rule, params map[string]string) (bool, error) {
+	defaultRules := []Rule{
+		rule.NotEmpty,
+		rule.Required,
+		rule.Enum,
+		rule.Max,
+		rule.Min,
+		rule.MaxBound,
+		rule.MinBound,
+		rule.IsBool,
+	}
+	return RawValidateWithParams(b, tn, append(defaultRules, customRules...), params)
+}
+
+func RawValidateWithParams(b any, tn string, rules []Rule, params map[string]string) (bool, error) {
+	fields, err := RawSerialize(tn, b)
+	if err != nil {
+		return false, err
+	}
+	return ValidateFieldsWithParams(fields, rules, params)
+}
+
+func ValidateFieldsWithParams(fields []Field, rules []Rule, params map[string]string) (bool, error) {
+	for _, field := range fields {
+		for _, r := range rules {
+			val, ok := field.Tags[r.Name()]
+			if !ok {
+				continue
+			}
+
+			val = substituteParams(val, params)
+			if ok, err := r.Validate(field.Name, field.Value, val); err != nil {
+				return ok, err
+			}
+		}
+	}
+	return true, nil
+}
+
+func substituteParams(s string, params map[string]string) string {
+	for k, v := range params {
+		needle := "{" + k + "}"
+		s = strings.ReplaceAll(s, needle, v)
+	}
+	return s
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/guiferpa/gody/v2/rule"
 	"github.com/guiferpa/gody/v2/rule/ruletest"
 )
 
@@ -106,5 +107,36 @@ func TestSetTagName(t *testing.T) {
 	if ce, ok := err.(*ErrEmptyTagName); !ok {
 		t.Errorf("Unexpected error type: got: %v, want: %v", reflect.TypeOf(ce), reflect.TypeOf(&ErrEmptyTagName{}))
 		return
+	}
+}
+
+func TestDynamicEnumParameterValidation(t *testing.T) {
+	type Status string
+	const (
+		StatusCreated Status = "__CREATED__"
+		StatusPending Status = "__PENDING__"
+		StatusDoing   Status = "__DOING__"
+		StatusDone    Status = "__DONE__"
+	)
+	type Task struct {
+		Name   string
+		Status Status `validate:"enum={status}"`
+	}
+	validator := NewValidator()
+	validator.AddRuleParameters(map[string]string{
+		"status": string(StatusCreated) + "," + string(StatusPending) + "," + string(StatusDoing) + "," + string(StatusDone),
+	})
+	validator.AddRules(rule.Enum)
+
+	task := Task{Name: "Test", Status: StatusCreated}
+	ok, err := validator.Validate(task)
+	if !ok || err != nil {
+		t.Errorf("expected valid enum, got ok=%v, err=%v", ok, err)
+	}
+
+	task.Status = "__INVALID__"
+	ok, err = validator.Validate(task)
+	if ok || err == nil {
+		t.Errorf("expected invalid enum, got ok=%v, err=%v", ok, err)
 	}
 }

--- a/validator.go
+++ b/validator.go
@@ -37,9 +37,6 @@ func (v *Validator) SetTagName(tn string) error {
 }
 
 func (v *Validator) AddRuleParameters(params map[string]string) {
-	if v.params == nil {
-		v.params = make(map[string]string)
-	}
 	for k, val := range params {
 		v.params[k] = val
 	}

--- a/validator.go
+++ b/validator.go
@@ -14,6 +14,7 @@ type Validator struct {
 	tagName    string
 	rulesMap   map[string]Rule
 	addedRules []Rule
+	params     map[string]string
 }
 
 func (v *Validator) AddRules(rs ...Rule) error {
@@ -35,13 +36,23 @@ func (v *Validator) SetTagName(tn string) error {
 	return nil
 }
 
+func (v *Validator) AddRuleParameters(params map[string]string) {
+	if v.params == nil {
+		v.params = make(map[string]string)
+	}
+	for k, val := range params {
+		v.params[k] = val
+	}
+}
+
 func (v *Validator) Validate(b any) (bool, error) {
-	return RawDefaultValidate(b, v.tagName, v.addedRules)
+	return RawDefaultValidateWithParams(b, v.tagName, v.addedRules, v.params)
 }
 
 func NewValidator() *Validator {
 	tagName := DefaultTagName
 	rulesMap := make(map[string]Rule)
 	addedRules := make([]Rule, 0)
-	return &Validator{tagName, rulesMap, addedRules}
+	params := make(map[string]string)
+	return &Validator{tagName, rulesMap, addedRules, params}
 }


### PR DESCRIPTION
This commit introduces dynamic enum validation using parameters, allowing you to avoid duplicating enum values in struct tags. Instead of hardcoding enum values in the validate tag, you can now reference a parameter (e.g., validate:"enum={status}") and set its value at runtime using validator.AddRuleParameters(...). This change improves maintainability and reduces duplication in your codebase.
**Key Changes:**
Added support for parameter substitution in validation tags.
Implemented AddRuleParameters in the Validator struct to set dynamic values for enum validation.
Updated the enum rule to return false for invalid values, ensuring consistent validation behavior.
Added tests to verify dynamic enum validation works as expected.
@guiferpa 
